### PR TITLE
Update webpack usage for instantiating shared worker of js

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ module.exports = {
       // Some language extensions like typescript are so huge that may impact build performance
       // e.g. Build full languages support with webpack 4.0 takes over 80 seconds
       // Languages are loaded on demand at runtime
-      languages: ['javascript', 'css', 'html']
+      languages: ['javascript', 'css', 'html', 'typescript']
     })
   ]
 }


### PR DESCRIPTION
As README of MonacoWebpackPlugin say:

![image](https://user-images.githubusercontent.com/6873700/59445373-20202f80-8e32-11e9-84f2-7214a54864b6.png)

If `language` includes `javascript` , it must includes `typescript`, too.

If `language` doesn't include `typescript`, it will have below error:

![image](https://user-images.githubusercontent.com/6873700/59445934-16e39280-8e33-11e9-8cb6-87bc90d7ae83.png)