### PR TITLE
feat: add editorWillMount event

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,19 +140,20 @@ window.MonacoEnvironment = {
 - `diffEditor`: `boolean` Indicate that this is a DiffEditor, `false` by default.
 
 ### Component Events
-#### `beforeCreateEditor`
+
+#### `editorWillMount`
 
 - Params:
   - `monaco`: [`monaco module`](https://microsoft.github.io/monaco-editor/api/index.html)
 
-before editor created.
+Called before mounting the editor.
 
 #### `editorDidMount`
 
 - Params:
   - `editor`: [`IStandaloneCodeEditor`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandalonecodeeditor.html) for normal editor, [`IStandaloneDiffEditor`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandalonediffeditor.html) for diff editor.
 
-Editor is created.
+Called when the editor is mounted.
 
 #### `change`
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ window.MonacoEnvironment = {
 - `diffEditor`: `boolean` Indicate that this is a DiffEditor, `false` by default.
 
 ### Component Events
+#### `beforeCreateEditor`
+
+- Params:
+  - `monaco`: [`monaco module`](https://microsoft.github.io/monaco-editor/api/index.html)
+
+before editor created.
 
 #### `editorDidMount`
 

--- a/src/MonacoEditor.js
+++ b/src/MonacoEditor.js
@@ -83,7 +83,7 @@ export default {
 
   methods: {
     initMonaco(monaco) {
-      this.$emit('editorWillMount', this.editor)
+      this.$emit('editorWillMount', this.monaco)
 
       const options = assign(
         {

--- a/src/MonacoEditor.js
+++ b/src/MonacoEditor.js
@@ -83,6 +83,8 @@ export default {
 
   methods: {
     initMonaco(monaco) {
+      this.$emit('beforeCreateEditor', this.monaco)
+
       const options = assign(
         {
           value: this.value,

--- a/src/MonacoEditor.js
+++ b/src/MonacoEditor.js
@@ -83,7 +83,7 @@ export default {
 
   methods: {
     initMonaco(monaco) {
-      this.$emit('beforeCreateEditor', this.monaco)
+      this.$emit('editorWillMount', this.editor)
 
       const options = assign(
         {


### PR DESCRIPTION
An event named "beforeCreateEditor" has been added to allow developers to process the Monaco object before creating the editor,Some plug-ins need to use the Monaco object, such as "emmet-monaco-es"